### PR TITLE
Remove health badge for django-statsd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,6 @@ Introduction
     :alt: Test Status
     :target: https://travis-ci.org/WoLpH/zfs-utils-osx
 
-.. image:: https://landscape.io/github/WoLpH/django-statsd/master/landscape.png
-   :target: https://landscape.io/github/WoLpH/django-statsd/master
-   :alt: Code Health
-
 .. image:: https://requires.io/github/WoLpH/zfs-utils-osx/requirements.png?branch=master
    :target: https://requires.io/github/WoLpH/zfs-utils-osx/requirements/?branch=master
    :alt: Requirements Status


### PR DESCRIPTION
Landscape isn't integrated with zfs-utils-osx or I would have replaced it with that.